### PR TITLE
Redirects

### DIFF
--- a/projects/example-micro-frontend/src/app/app-routing.module.ts
+++ b/projects/example-micro-frontend/src/app/app-routing.module.ts
@@ -21,13 +21,17 @@ const routes: Routes = [
         path: 'child',
         component: ChildPageComponent,
       },
+      {
+        path: 'redirect',
+        redirectTo: 'child',
+      },
     ],
   },
   { path: '**', component: NoComponent },
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { enableTracing: true })],
   providers: [{ provide: LocationStrategy, useClass: NoopLocationStrategy }],
   exports: [RouterModule],
 })

--- a/projects/example-micro-frontend/src/app/entry.component.ts
+++ b/projects/example-micro-frontend/src/app/entry.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   Output,
 } from '@angular/core';
+import { RouterEvent } from '../../../ngx-elements-router/src/lib/router-event.type';
 import { EntryRoutingService } from '../../../ngx-elements-router/src/lib/entry-routing.service';
 import { Subject, Subscription } from 'rxjs';
 
@@ -16,7 +17,7 @@ import { Subject, Subscription } from 'rxjs';
 export class EntryComponent implements OnChanges, OnDestroy {
   private route$ = new Subject<string | undefined>();
   @Input() route?: string;
-  @Output() routeChange = new EventEmitter<string>();
+  @Output() routeChange = new EventEmitter<RouterEvent>();
 
   private readonly subscription: Subscription;
 

--- a/projects/ngx-elements-router/src/dev-platform.js
+++ b/projects/ngx-elements-router/src/dev-platform.js
@@ -22,14 +22,18 @@ function registerRouting(base, tagName) {
   }
   return {
     changeRoute(route) {
-      pushState(route);
+      changeBrowserUrl(route, false);
       adaptOutlet(base, route, outlet, tagName);
     },
   };
 }
 
-function pushState(route) {
-  window.history.pushState("", "", route);
+function changeBrowserUrl(url, replaceUrl) {
+  if (replaceUrl) {
+    window.history.replaceState("", "", url);
+  } else {
+    window.history.pushState("", "", url);
+  }
 }
 
 function adaptOutlet(base, route, outlet, tagName) {
@@ -52,7 +56,7 @@ function adaptOutlet(base, route, outlet, tagName) {
 function addRoutingToElement(base, outlet, element) {
   element.addEventListener("routeChange", (event) => {
     const route = event.detail;
-    pushState(route);
-    adaptOutlet(base, route, outlet, element);
+    changeBrowserUrl(route.url, route.replaceUrl);
+    adaptOutlet(base, route.url, outlet, element);
   });
 }

--- a/projects/ngx-elements-router/src/lib/entry-routing.service.ts
+++ b/projects/ngx-elements-router/src/lib/entry-routing.service.ts
@@ -50,7 +50,8 @@ export class EntryRoutingService {
     return this.router.events.subscribe((event) => {
       if (
         event instanceof RoutesRecognized &&
-        !this.router.getCurrentNavigation()?.extras.skipLocationChange
+        (!this.router.getCurrentNavigation()?.extras.skipLocationChange ||
+          event.url !== event.urlAfterRedirects)
       ) {
         outgoingRoute$.next(event.urlAfterRedirects);
       }

--- a/projects/ngx-elements-router/src/lib/entry-routing.service.ts
+++ b/projects/ngx-elements-router/src/lib/entry-routing.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { NavigationStart, Router } from '@angular/router';
+import { Router, RoutesRecognized } from '@angular/router';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 
@@ -49,10 +49,10 @@ export class EntryRoutingService {
   registerOutgoingRouting(outgoingRoute$: Subject<string>): Subscription {
     return this.router.events.subscribe((event) => {
       if (
-        event instanceof NavigationStart &&
+        event instanceof RoutesRecognized &&
         !this.router.getCurrentNavigation()?.extras.skipLocationChange
       ) {
-        outgoingRoute$.next(event.url);
+        outgoingRoute$.next(event.urlAfterRedirects);
       }
     });
   }

--- a/projects/ngx-elements-router/src/lib/router-event.type.ts
+++ b/projects/ngx-elements-router/src/lib/router-event.type.ts
@@ -1,0 +1,14 @@
+/**
+ * An event sent from the micro frontend to the platform to indicate that the route within the micro frontend has changed.
+ */
+export interface RouterEvent {
+  /**
+   * The new absolute url without the base href, e.g. `/micro-frontend/child`.
+   */
+  url: string;
+  /**
+   * If the new url is replacing the current url or if this url is a new entry in the browser history.
+   * A replace is used for redirects.
+   */
+  replaceUrl: boolean;
+}

--- a/projects/ngx-elements-router/src/lib/routing.directive.spec.ts
+++ b/projects/ngx-elements-router/src/lib/routing.directive.spec.ts
@@ -4,11 +4,11 @@ import { RoutingDirective } from './routing.directive';
 describe('RoutingDirective', () => {
   let directive: RoutingDirective;
   let navigateByUrlSpy: jest.SpyInstance;
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
 
   beforeEach(() => {
     const router: Partial<Router> = {
       navigateByUrl: () => Promise.resolve(true),
-      navigate: () => Promise.resolve(true),
     };
     const activatedRoute = {
       parent: 'parent',
@@ -22,17 +22,17 @@ describe('RoutingDirective', () => {
   });
 
   it('navigates to the url', () => {
-    directive.navigateToUrl('/a/b');
-    expect(navigateByUrlSpy).toBeCalledWith('/a/b');
+    directive.navigateToUrl({ url: '/a/b', replaceUrl: false });
+    expect(navigateByUrlSpy).toBeCalledWith('/a/b', { replaceUrl: false });
   });
 
   it('navigates to / if the route is /', () => {
-    directive.navigateToUrl('/');
-    expect(navigateByUrlSpy).toBeCalledWith('/');
+    directive.navigateToUrl({ url: '/', replaceUrl: false });
+    expect(navigateByUrlSpy).toBeCalledWith('/', { replaceUrl: false });
   });
 
   it('does not navigate on relative urls', () => {
-    directive.navigateToUrl('./');
+    directive.navigateToUrl({ url: './', replaceUrl: false });
     expect(navigateByUrlSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/projects/ngx-elements-router/src/lib/routing.directive.ts
+++ b/projects/ngx-elements-router/src/lib/routing.directive.ts
@@ -5,9 +5,10 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
+import { RouterEvent } from './router-event.type';
 
 /**
  * Enables the routing feature on a custom element.
@@ -50,16 +51,19 @@ export class RoutingDirective implements OnInit, OnDestroy {
   }
 
   @HostListener('routeChange', ['$event'])
-  handleRouteChange(event: { detail?: string }): void {
+  handleRouteChange(event: { detail?: RouterEvent }): void {
     this.navigateToUrl(event?.detail);
   }
 
-  navigateToUrl(url: string | undefined): void {
-    if (url && url.startsWith('/')) {
-      this.router.navigateByUrl(url);
+  navigateToUrl(event: RouterEvent | undefined): void {
+    if (event?.url && event.url.startsWith('/')) {
+      this.router.navigateByUrl(event.url, {
+        replaceUrl: event.replaceUrl || false,
+      });
     } else {
       console.warn(
-        `The aerRouting retrieved a route change that does not start with a '/'.`
+        `The aerRouting directive received an invalid router event.`,
+        event
       );
     }
   }

--- a/projects/ngx-elements-router/src/public-api.ts
+++ b/projects/ngx-elements-router/src/public-api.ts
@@ -3,5 +3,6 @@ export * from './lib/entry-routing.service';
 export * from './lib/noop-location-strategy';
 export * from './lib/no.component';
 export * from './lib/load-bundle.guard';
+export * from './lib/router-event.type';
 export * from './lib/routing.directive';
 export * from './lib/elements-router.module';


### PR DESCRIPTION
Closes #1 .

In the micro frontend, it is now possible to define redirects in the routes of the router module. They are processed in the micro frontends router module. The url after the redirect is then passed on to the platform.  

The `routeChange` output of the custom element now passes objects with the url and a boolean `replaceUrl`. If that boolean is set, then the browser url is replaced instead of that another entry is added.